### PR TITLE
Reduce docker image size from 1.1G to 321MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.6
+FROM python:3.6-slim
 ADD . /src
 WORKDIR /src
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 CMD python ./src/flask_server.py


### PR DESCRIPTION
The `slim` image does not loose any meaningful functionality, and this may make the image way faster to push/pull on low bandwidth scenarios.
Also, pip does not require cache for a docker image, that save a couple of extra MB.